### PR TITLE
docs: standardize README to Open Paws ecosystem template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,61 @@
-# No Animal Violence — pre-commit hook
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.2.0-blue)](https://github.com/Open-Paws/no-animal-violence-pre-commit/releases)
+[![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/)
+[![Last Commit](https://img.shields.io/github/last-commit/Open-Paws/no-animal-violence-pre-commit)](https://github.com/Open-Paws/no-animal-violence-pre-commit/commits/main)
 
-> **Status: 🟢 Production** | Part of the [Open Paws](https://openpaws.ai) speciesist-language detection ecosystem
+# no-animal-violence-pre-commit
 
-A [pre-commit](https://pre-commit.com) hook that detects language normalizing harm to animals in code and documentation, suggesting clearer professional alternatives. This is the **earliest enforcement point** in the development workflow — violations are caught locally before any code leaves the developer's machine.
+A [pre-commit](https://pre-commit.com) hook that scans staged files for language that normalizes harm to animals — idioms, industry euphemisms, and tech jargon — and suggests clearer alternatives. It runs locally before any code leaves the developer's machine, making it the earliest enforcement point in the development workflow. No external dependencies; patterns compile at import time.
 
----
+> [!NOTE]
+> This project is part of the [Open Paws](https://openpaws.ai) ecosystem — AI infrastructure for the animal liberation movement. [Explore the full platform →](https://github.com/Open-Paws)
 
-## Ecosystem
-
-This hook is one layer in a multi-tool detection suite:
-
-| Tool | Enforcement point |
-|------|-------------------|
-| **no-animal-violence-pre-commit** ← you are here | Local git commit |
-| [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) | GitHub Actions CI |
-| [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) | PR inline annotations |
-| [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) | JS/TS editor + lint |
-| [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) | Prose / docs |
-| [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) | VS Code extension |
-
-Canonical pattern dictionary: [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) (65+ patterns, source of truth for the entire ecosystem).
-
----
-
-## Installation
-
-### Minimal setup
-
-Add to your `.pre-commit-config.yaml`:
+## Usage
 
 ```yaml
+# .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Open-Paws/no-animal-violence-pre-commit
     rev: v0.2.0
     hooks:
       - id: no-animal-violence
+        files: \.(py|ts|js|md|yaml|yml)$   # recommended: limit to text files
+        exclude: ^tests/fixtures/           # optional: skip known-bad fixtures
 ```
 
-Then install and run:
+## Quickstart
 
+1. Install pre-commit:
+   ```bash
+   pip install pre-commit
+   ```
+2. Add the hook config above to `.pre-commit-config.yaml` in your repository root.
+3. Install the hooks:
+   ```bash
+   pre-commit install
+   ```
+4. Run against all existing files (recommended on first install):
+   ```bash
+   pre-commit run no-animal-violence --all-files
+   ```
+5. From this point on, the hook runs automatically on every `git commit`.
+
+**Run without installing** (one-shot scan):
 ```bash
-pre-commit install
-pre-commit run --all-files   # scan everything on first install
-```
-
-### Limit to specific file types (recommended)
-
-```yaml
-repos:
-  - repo: https://github.com/Open-Paws/no-animal-violence-pre-commit
-    rev: v0.2.0
-    hooks:
-      - id: no-animal-violence
-        files: \.(py|ts|js|md|yaml|yml)$
-```
-
-### Run manually without installing
-
-```bash
-pip install pre-commit
 pre-commit try-repo https://github.com/Open-Paws/no-animal-violence-pre-commit no-animal-violence --all-files
 ```
 
----
+## Features
 
-## Hooks
+### What it checks
 
-### `no-animal-violence`
+The hook scans each staged file line-by-line against 65+ compiled regular expressions (case-insensitive) covering three categories:
 
-| Property | Value |
-|----------|-------|
-| Language | Python (no external dependencies) |
-| Entry point | `no-animal-violence-check` console script |
-| File types | All text files (or filtered by `files:` pattern) |
-| Stage | `pre-commit` |
-| Exit code | `0` = clean, `1` = violations found |
+- **Animal idioms in code and prose** — `kill two birds with one stone`, `guinea pig`, `cattle vs. pets`, `herding cats`, `canary in the coal mine`, and 30+ others
+- **Industry euphemisms for exploitation** — `livestock` → farmed animals, `processing plant` → slaughterhouse, `humane slaughter`, `spent hens`, `depopulation`, and others
+- **Tech jargon with harmful roots** — `master/slave` → primary/replica, `whitelist/blacklist` → allowlist/denylist, `cowboy coding`, `code monkey`, `dogfooding`
 
-The hook scans each staged file line-by-line against 65+ compiled regular expressions. On any match it prints the file path, line number, matched phrase, and the suggested alternative, then exits non-zero to block the commit.
-
----
-
-## Example output
+On any match the hook prints the file path, line number, matched phrase, and suggested alternative, then exits non-zero to block the commit:
 
 ```
 Animal violence language detected:
@@ -96,150 +71,113 @@ Animal violence language detected:
 2 instance(s) found. Consider using the suggested alternatives.
 ```
 
-Fix the flagged phrases and re-stage to proceed with the commit.
+Fix the flagged phrases, re-stage, and commit again.
 
----
+### Configuration options
 
-## Phrase reference
+All filtering uses standard pre-commit arguments — no environment variables or config files are required:
 
-The hook detects all of the following (case-insensitive):
+| Option | Example | Effect |
+|--------|---------|--------|
+| `files` | `\.(py|ts|js|md)$` | Limit to specific extensions |
+| `exclude` | `^tests/fixtures/` | Skip paths matching the pattern |
+| `stages` | `[pre-commit, manual]` | Control when the hook runs |
 
-| Phrase | Suggested alternative |
-|--------|-----------------------|
-| kill two birds with one stone | accomplish two things at once |
-| beat a dead horse | belabor the point |
-| more than one way to skin a cat | more than one way to solve this |
-| let the cat out of the bag | reveal the secret |
-| open a can of worms | create a complicated situation |
-| wild goose chase | futile search |
-| like shooting fish in a barrel | trivially easy |
-| flog a dead horse | belabor the point |
-| bigger fish to fry | more important matters to address |
-| guinea pig | test subject |
-| hold your horses | wait a moment |
-| the elephant in the room | the obvious issue |
-| straight from the horse's mouth | directly from the source |
-| bring home the bacon | bring home the results |
-| take the bull by the horns | face the challenge head-on |
-| like lambs to the slaughter | without resistance |
-| no room to swing a cat | very cramped |
-| red herring | distraction |
-| curiosity killed the cat | curiosity backfired |
-| like a chicken with its head cut off | in a panic |
-| your goose is cooked | you're in trouble |
-| throwing someone to the wolves | abandon to criticism |
-| hook, line, and sinker | completely |
-| clip someone's wings | restrict someone's freedom |
-| straw that broke the camel's back | the tipping point |
-| bird in the hand worth two in the bush | a sure thing beats a possibility |
-| eating crow | admit being wrong |
-| fighting like cats and dogs | constantly argue |
-| take the bait | fall for it |
-| don't count your chickens | don't assume success prematurely |
-| livestock | farmed animals |
-| poultry | farmed birds |
-| gestation crates | pregnancy cage |
-| depopulation | mass killing |
-| processing plant/facility | slaughterhouse |
-| farrowing crates | birthing cage |
-| battery cages | small wire cage |
-| spent hens | discarded hen |
-| humane slaughter / humane killing | slaughter |
-| broilers | chicken raised for meat |
-| don't be a chicken | don't hesitate |
-| code/memory/resource pig | resource-intensive |
-| cowboy coding/coder | undisciplined coding |
-| code monkey | developer |
-| badgering | pestering |
-| ferreting out | uncover |
-| cattle vs. pets | ephemeral vs. persistent |
-| pet project | side project |
-| canary in the coal mine | early warning signal |
-| dogfooding | self-hosting |
-| herding cats | coordinating independent contributors |
-| fishing expedition | exploratory investigation |
-| sacred cow | unquestioned belief |
-| scapegoat | blame target |
-| rat race | daily grind |
-| dead cat bounce | temporary rebound |
-| dog-eat-dog | ruthlessly competitive |
-| whack-a-mole | recurring problem |
-| cash cow | profit center |
-| sacrificial lamb | expendable person |
-| sitting duck | easy target |
-| open season | free-for-all |
-| put out to pasture | retire |
-| dead duck | lost cause |
-| kill the process | terminate the process |
-| kill the server | stop the server |
-| nuke it | delete completely |
-| abort | cancel |
-| cull | remove |
-| master/slave | primary/replica |
-| whitelist/blacklist | allowlist/denylist |
-| grandfathered | legacy |
+All patterns are built in. There is no external config file to maintain.
 
-For the authoritative pattern list and rationale, see the [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) canonical dictionary.
+### Running as a standalone script
 
----
-
-## Configuration options
-
-The hook accepts standard pre-commit filtering arguments in your config:
-
-```yaml
-- id: no-animal-violence
-  files: \.(py|ts|js|md|yaml|yml)$   # limit to specific extensions
-  exclude: ^tests/fixtures/           # exclude paths
-  args: []                            # no additional CLI args supported
-```
-
-No environment variables or config files are required. All patterns are built in.
-
----
-
-## Running directly (without pre-commit)
-
-The scanner can be invoked as a standalone script:
+The scanner can also be invoked directly, outside of pre-commit:
 
 ```bash
-# Install
 pip install git+https://github.com/Open-Paws/no-animal-violence-pre-commit.git
 
-# Run against files
 no-animal-violence-check src/utils.py docs/README.md
-
-# Or via Python directly
-python no_animal_violence_check.py src/utils.py
 ```
 
-Exit code `0` = no violations. Exit code `1` = one or more violations found.
+Exit code `0` = clean. Exit code `1` = one or more violations found.
 
----
+## Documentation
 
-## Relationship to the canonical pattern dictionary
+- [Canonical pattern dictionary](https://github.com/Open-Paws/no-animal-violence) — authoritative source for all 65+ patterns and rationale
+- [pre-commit documentation](https://pre-commit.com/docs) — general hook configuration reference
+- [`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml) — hook manifest for this repo
 
-The patterns in `no_animal_violence_check.py` are derived from the [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) canonical dictionary. Currently they are maintained as a copy in this repository (known DRY limitation — tracked for future resolution). Until automatic sync is implemented, any pattern changes must be applied consistently in both repos.
+### Ecosystem
 
-The same 65+ pattern set is also enforced at agent-generation time by `mcp-server-nav-language` in the Gary MCP hub, providing end-to-end coverage from developer commit through to AI agent output.
+This hook is one layer in a multi-tool detection suite. Each tool targets a different enforcement point:
 
----
+| Tool | Enforcement point |
+|------|-------------------|
+| **no-animal-violence-pre-commit** ← you are here | Local git commit |
+| [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) | GitHub Actions CI |
+| [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) | PR inline annotations |
+| [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) | JS/TS editor + lint |
+| [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) | Prose / docs |
+| [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) | VS Code extension |
+| [danger-plugin-no-animal-violence](https://github.com/Open-Paws/danger-plugin-no-animal-violence) | Danger.js PR checks |
+
+## Architecture
+
+<details>
+<summary>Implementation details</summary>
+
+The hook is a single Python file (`no_animal_violence_check.py`) with no runtime dependencies beyond the standard library.
+
+**Pattern structure:** Each entry in `PATTERNS` is a `(regex_string, alternative_string)` tuple. All patterns are compiled once at module load time into `COMPILED` using `re.IGNORECASE`.
+
+**Execution flow:**
+1. `pre-commit` calls the `no-animal-violence-check` console script with a list of staged filenames as arguments.
+2. `main()` iterates over each filename and calls `check_file()`.
+3. `check_file()` opens the file in UTF-8 mode (with error replacement for binary content), iterates line-by-line, and runs all compiled regexes via `finditer`.
+4. Findings are collected as `(filepath, line_number, matched_text, alternative)` tuples.
+5. If any findings exist, they are printed to stdout and the process exits with code `1`, blocking the commit.
+
+**Pattern source:** Patterns are auto-generated from [project-compassionate-code](https://github.com/Open-Paws/project-compassionate-code) and derived from the [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) canonical dictionary. The pattern list in this repo is currently maintained as a copy (a known DRY limitation tracked for future resolution). Pattern changes must be applied consistently in both repos until automatic sync is implemented.
+
+**Python requirement:** 3.8+. The hook is registered in `.pre-commit-hooks.yaml` with `language: python` and `types: [text]`.
+
+</details>
 
 ## Contributing
 
+Contributions are welcome — especially new patterns. The most useful additions are phrases that appear in real codebases and have clear, professionally neutral alternatives.
+
 1. Fork the repository and create a feature branch.
 2. Patterns live in the `PATTERNS` list in `no_animal_violence_check.py`. Each entry is a `(regex, alternative)` tuple.
-3. Run the test suite before opening a pull request:
+3. Run the test suite:
    ```bash
    python -m pytest tests/
    ```
-4. Verify the hook works end-to-end:
+4. Verify the hook end-to-end:
    ```bash
    pre-commit try-repo . no-animal-violence --all-files
    ```
-5. Check that new patterns align with the [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) canonical dictionary — open a parallel PR there if adding new phrases.
-6. Keep alternatives in movement-standard language: "farmed animals" not "livestock", "slaughterhouse" not "processing facility".
+5. Open a parallel PR in [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) if adding a new phrase to the canonical dictionary.
+6. Use movement-standard language in alternatives: "farmed animals" not "livestock", "slaughterhouse" not "processing facility".
 
 ---
 
-MIT License — [Open Paws](https://openpaws.ai)
+<!-- TODO: add adoption/usage numbers once available from GitHub dependency graph or package download stats -->
+
+## License
+
+MIT — see [LICENSE](LICENSE). Copyright (c) 2026 Open Paws.
+
+## Acknowledgments
+
+Pattern dictionary maintained by the Open Paws community. This hook is auto-generated from [project-compassionate-code](https://github.com/Open-Paws/project-compassionate-code), which submits animal-friendly PRs to open-source repositories at scale.
+
+---
+
+[Donate](https://openpaws.ai/donate) · [Discord](https://discord.gg/openpaws) · [openpaws.ai](https://openpaws.ai) · [Volunteer](https://openpaws.ai/volunteer)
+
+---
+
+<!-- Metadata
+tech_stack: Python, pre-commit
+project_status: production
+difficulty: beginner
+skill_tags: pre-commit, language-linting, speciesist-language, advocacy-tooling, python
+related_repos: no-animal-violence, no-animal-violence-action, reviewdog-no-animal-violence, eslint-plugin-no-animal-violence, vale-no-animal-violence, vscode-no-animal-violence, danger-plugin-no-animal-violence, project-compassionate-code
+-->


### PR DESCRIPTION
## Summary

- Rewrites README to the Open Paws ecosystem standard template
- Adds badge row (license, version, Python, last-commit), TL;DR, ecosystem note, usage snippet, quickstart, features table, architecture `<details>` block, contributing guidance, and standard footer
- Marks adoption/impact section as `<!-- TODO -->` (no fabricated numbers); all other content is grounded in actual source files (`no_animal_violence_check.py`, `setup.py`, `.pre-commit-hooks.yaml`)

## Test plan

- [ ] Review rendered Markdown on the PR preview tab
- [ ] Confirm badge links resolve correctly
- [ ] Confirm all ecosystem repo links point to real Open-Paws repos
- [ ] Confirm no fabricated statistics or version numbers beyond what is in `setup.py` (v0.2.0)
