### PR TITLE
fix(tests): unpack 5-tuple from check_file instead of 4

### DIFF
--- a/tests/test_no_animal_violence_check.py
+++ b/tests/test_no_animal_violence_check.py
@@ -22,7 +22,7 @@ class TestCheckFile(unittest.TestCase):
         try:
             findings = check_file(path)
             self.assertEqual(len(findings), 1)
-            filepath, line_num, matched, alternative = findings[0]
+            filepath, line_num, matched, alternative, reason = findings[0]
             self.assertEqual(line_num, 1)
             self.assertIn("accomplish two things at once", alternative)
         finally:


### PR DESCRIPTION
## Summary

`check_file()` returns 5-tuples `(filepath, line_num, matched, alternative, reason)` but `test_detects_known_idiom` was unpacking only 4 values, causing `ValueError: too many values to unpack`. The test was broken by the addition of `reason` to the return tuple when the implementation was updated.

## Test plan
- [ ] `python3 -m pytest tests/` — all 8 tests pass (was 7/8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to validate that findings now include an additional reason field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->