### PR TITLE
fix(ci): add canonical CodeQL workflow with security-extended

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,3 +40,4 @@ jobs:
         name: Perform CodeQL Analysis
         with:
           category: "/language:${{ matrix.language }}"
+          upload: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  packages: read
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+        name: Initialize CodeQL
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+        name: Perform CodeQL Analysis
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

`no-animal-violence-pre-commit` is classified as **Tooling/plugin library** per `handbook/ci-cd.md:11-18` (CodeQL: Custom + `security-extended`). Currently runs CodeQL via Default Setup ONLY, which silently downgrades the query pack to `security-and-quality` — handbook violation since this repo runs inside other developers' CI environments and needs the extended pack.

## What this PR does

Adds `.github/workflows/codeql.yml` per the canonical skeleton in `handbook/ci-cd.md:98-147`:

- language: `python`
- queries: `security-extended` (handbook Q2 mandate)
- `build-mode: none` (Python is interpreted; explicit per Q4)
- SHA-pinned third-party actions per `decisions.md` 2026-04-19:
  - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1`
  - `github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2`
  - `github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2`
- `persist-credentials: false` on checkout (least privilege)

## Operator follow-up — order matters

Disable Default Setup AFTER this PR merges AND one file-workflow run shows success. Reverse order leaves a coverage gap. Tracked in the parent fleet ops issue.

Refs Open-Paws/no-animal-violence#62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated security scanning workflow (CodeQL) that runs on main branch changes, pull requests, a weekly schedule, and via manual trigger to provide continuous vulnerability analysis.
  * Analysis results are collected and uploaded for non-pull-request runs to support ongoing monitoring and triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->